### PR TITLE
Reply gesture to "reply" to a paragraph

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -57,6 +57,7 @@ Whenever I tell you to build, run, or compile the project I expect you to use th
 - **Swipe right-to-left on NoteView**: Create new note
 - **Swipe right-to-left on ContentView**: Navigate to last edited note
 - **Swipe actions**: Pin/unpin and delete notes
+- **Drag-to-Reorder**: Long-press to drag paragraphs.
 
 **Utilities:**
 - `KeyboardObserver.swift`: Keyboard visibility and height changes
@@ -113,6 +114,9 @@ Whenever I tell you to build, run, or compile the project I expect you to use th
   - **Multitouch Support**: One finger holds paragraph, second finger scrolls
   - **Smooth Animations**: 0.2s fade transitions for visual feedback
   - **Haptic Feedback**: Light impact on drop, selection feedback on target changes
+- **Reply Gesture**: Swipe a paragraph to the right to create a new paragraph below it.
+  - **Visual Feedback**: The paragraph is duplicated and follows the finger. The original paragraph is obscured.
+  - **Haptic Feedback**: A light haptic feedback is triggered when the gesture is completed.
 
 **Visual System:**
 - **RuledView**: Real-time paragraph visualization with semi-transparent overlays

--- a/notes2/RichTextEditor+Gestures.swift
+++ b/notes2/RichTextEditor+Gestures.swift
@@ -1,6 +1,0 @@
-import UIKit
-import SwiftUI
-
-extension RichTextEditor.Coordinator {
-    // Gesture handling methods are now in the main Coordinator class
-}

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1654,8 +1654,9 @@ struct RichTextEditor: UIViewRepresentable {
             textView.attributedText = mutableText
             parent.text = mutableText
             
-            // Set cursor position at the start of the new paragraph
-            let cursorPosition = insertLocation + 1 // After the newline
+            // Handle cursor positioning for edge case of last paragraph
+            let isLastParagraph = paragraphIndex == paragraphs.count - 1
+            let cursorPosition = isLastParagraph ? insertLocation + 1 : insertLocation
             textView.selectedRange = NSRange(location: cursorPosition, length: 0)
             parent.selectedRange = textView.selectedRange
             

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1703,8 +1703,7 @@ struct RichTextEditor: UIViewRepresentable {
         }
 
         private func cleanupReplyGesture() {
-            guard let ghostView = replyGhostView, let overlayView = replyOverlayView else {
-                // Fallback to immediate cleanup if views don't exist
+            func cleanup() {
                 self.replyGhostView?.removeFromSuperview()
                 self.replyOverlayView?.removeFromSuperview()
                 self.replyGhostView = nil
@@ -1713,6 +1712,11 @@ struct RichTextEditor: UIViewRepresentable {
                 self.replyGestureInitialLocation = nil
                 self.hasTriggeredReplyHaptic = false
                 self.isHorizontalSwipe = false
+            }
+
+            guard let ghostView = replyGhostView, let overlayView = replyOverlayView else {
+                // Fallback to immediate cleanup if views don't exist
+                cleanup()
                 return
             }
 
@@ -1727,14 +1731,7 @@ struct RichTextEditor: UIViewRepresentable {
                     ghostView.transform = CGAffineTransform.identity
                 },
                 completion: { _ in
-                    self.replyGhostView?.removeFromSuperview()
-                    self.replyOverlayView?.removeFromSuperview()
-                    self.replyGhostView = nil
-                    self.replyOverlayView = nil
-                    self.replyGestureParagraphIndex = nil
-                    self.replyGestureInitialLocation = nil
-                    self.hasTriggeredReplyHaptic = false
-                    self.isHorizontalSwipe = false
+                    cleanup()
                 }
             )
         }

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1617,7 +1617,12 @@ struct RichTextEditor: UIViewRepresentable {
             newParagraphStyle.paragraphSpacing = AppSettings.relatedParagraphSpacing // Always related spacing between paragraphs
             
             // Use the same font as the original paragraph or fallback to typing attributes
-            let originalAttributes = originalParagraph.content.attributes(at: 0, effectiveRange: nil)
+            let originalAttributes: [NSAttributedString.Key: Any]
+            if originalParagraph.content.length > 0 {
+                originalAttributes = originalParagraph.content.attributes(at: 0, effectiveRange: nil)
+            } else {
+                originalAttributes = textView.typingAttributes
+            }
             let font = originalAttributes[.font] as? UIFont ?? textView.typingAttributes[.font] as? UIFont ?? UIFont.preferredFont(forTextStyle: .body)
             
             let newAttributes: [NSAttributedString.Key: Any] = [

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1587,7 +1587,7 @@ struct RichTextEditor: UIViewRepresentable {
         }
 
         private func handleReplyGestureEnded(gesture: UIPanGestureRecognizer, textView: UITextView) {
-            guard let ghostView = replyGhostView else { return }
+            guard replyGhostView != nil else { return }
             let translation = gesture.translation(in: textView)
             let horizontalTranslation = max(0, translation.x)
 
@@ -1714,7 +1714,7 @@ struct RichTextEditor: UIViewRepresentable {
                 self.isHorizontalSwipe = false
             }
 
-            guard let ghostView = replyGhostView, let overlayView = replyOverlayView else {
+            guard let ghostView = replyGhostView, replyOverlayView != nil else {
                 // Fallback to immediate cleanup if views don't exist
                 cleanup()
                 return

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -707,7 +707,7 @@ struct RichTextEditor: UIViewRepresentable {
         }
 
         @objc func handlePinchGesture(_ gesture: UIPinchGestureRecognizer) {
-            guard let textView = textView else { return }
+            guard let textView = textView, !isDragging else { return }
 
             if gesture.state == .began && gesture.numberOfTouches >= 2 {
                 handlePinchBegan(gesture, textView: textView)
@@ -1506,7 +1506,7 @@ struct RichTextEditor: UIViewRepresentable {
         // MARK: - Reply Gesture Handling
         
         @objc func handleSwipeToReplyGesture(_ gesture: UIPanGestureRecognizer) {
-            guard let textView = textView, !isDragging else { return }
+            guard let textView = textView, !isDragging, !isPinching else { return }
             let location = gesture.location(in: textView)
             
             switch gesture.state {

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1604,10 +1604,8 @@ struct RichTextEditor: UIViewRepresentable {
         }
         
         private func cleanupReplyGesture() {
-            UIView.animate(withDuration: 0.2, animations: {
-                self.replyGhostView?.alpha = 0
-                self.replyOverlayView?.alpha = 0
-            }, completion: { _ in
+            guard let ghostView = replyGhostView, let overlayView = replyOverlayView else {
+                // Fallback to immediate cleanup if views don't exist
                 self.replyGhostView?.removeFromSuperview()
                 self.replyOverlayView?.removeFromSuperview()
                 self.replyGhostView = nil
@@ -1615,7 +1613,30 @@ struct RichTextEditor: UIViewRepresentable {
                 self.replyGestureParagraphIndex = nil
                 self.replyGestureInitialLocation = nil
                 self.hasTriggeredReplyHaptic = false
-            })
+                return
+            }
+            
+            // Spring animation for ghost return to original position
+            UIView.animate(
+                withDuration: 0.3,
+                delay: 0,
+                usingSpringWithDamping: 0.8,
+                initialSpringVelocity: 0.5,
+                options: [.curveEaseOut, .allowUserInteraction],
+                animations: {
+                    ghostView.transform = CGAffineTransform.identity
+                    overlayView.alpha = 0
+                },
+                completion: { _ in
+                    self.replyGhostView?.removeFromSuperview()
+                    self.replyOverlayView?.removeFromSuperview()
+                    self.replyGhostView = nil
+                    self.replyOverlayView = nil
+                    self.replyGestureParagraphIndex = nil
+                    self.replyGestureInitialLocation = nil
+                    self.hasTriggeredReplyHaptic = false
+                }
+            )
         }
     }
 }

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1506,7 +1506,7 @@ struct RichTextEditor: UIViewRepresentable {
         // MARK: - Reply Gesture Handling
         
         @objc func handleSwipeToReplyGesture(_ gesture: UIPanGestureRecognizer) {
-            guard let textView = textView else { return }
+            guard let textView = textView, !isDragging else { return }
             let location = gesture.location(in: textView)
             
             switch gesture.state {


### PR DESCRIPTION
Swipe from left to right on a paragraph as if replying to a message on WhatsApp to insert a related paragraph directly below it. Saves the user having to move the cursor to the end of the paragraph then pressing enter. It will also automatically move the cursor the to the start of the new paragraph and show the keyboard if not already visible.