### PR TITLE
Paragraph delete gesture

### DIFF
--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1800,10 +1800,10 @@ struct RichTextEditor: UIViewRepresentable {
                 // Use rebuild logic for proper paragraph handling
                 var newParagraphs = paragraphs
                 newParagraphs.remove(at: paragraphIndex)
-                
+
                 // Rebuild the entire text using proven logic
                 let newAttributedString = rebuildAttributedString(from: newParagraphs)
-                
+
                 textView.attributedText = newAttributedString
                 parent.text = newAttributedString
 

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1812,10 +1812,6 @@ struct RichTextEditor: UIViewRepresentable {
 
             // Update paragraphs and ensure cursor is visible
             self.parseAttributedText(textView.attributedText)
-            DispatchQueue.main.async {
-                self.centerCursorInTextView()
-                textView.becomeFirstResponder()
-            }
         }
 
         private func cleanupReplyGesture() {

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1678,12 +1678,10 @@ struct RichTextEditor: UIViewRepresentable {
                 }
             }
 
-            // Track threshold crossings for traditional haptic feedback (fallback)
+            // Track threshold crossings for haptic feedback
             let wasAboveThreshold = hasTriggeredReplyHaptic
             if isAboveThreshold && !wasAboveThreshold {
-                if swipeDirection == .right {
-                    replyGestureHapticGenerator.impactOccurred() // Reply uses immediate confirmation
-                }
+                replyGestureHapticGenerator.impactOccurred() // Trigger haptic for both directions
                 hasTriggeredReplyHaptic = true
             } else if !isAboveThreshold && wasAboveThreshold {
                 hasTriggeredReplyHaptic = false

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1797,15 +1797,18 @@ struct RichTextEditor: UIViewRepresentable {
                 textView.selectedRange = NSRange(location: 0, length: 0)
                 parent.selectedRange = textView.selectedRange
             } else {
-                // Normal deletion for multiple paragraphs
-                let mutableText = NSMutableAttributedString(attributedString: textView.attributedText)
-                mutableText.deleteCharacters(in: deleteRange)
+                // Use rebuild logic for proper paragraph handling
+                var newParagraphs = paragraphs
+                newParagraphs.remove(at: paragraphIndex)
+                
+                // Rebuild the entire text using proven logic
+                let newAttributedString = rebuildAttributedString(from: newParagraphs)
+                
+                textView.attributedText = newAttributedString
+                parent.text = newAttributedString
 
-                textView.attributedText = mutableText
-                parent.text = mutableText
-
-                // Position cursor at start of deleted paragraph's location
-                let cursorLocation = min(deleteRange.location, mutableText.length)
+                // Position cursor appropriately based on deletion
+                let cursorLocation = min(deleteRange.location, newAttributedString.length)
                 textView.selectedRange = NSRange(location: cursorLocation, length: 0)
                 parent.selectedRange = textView.selectedRange
             }

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1613,15 +1613,15 @@ struct RichTextEditor: UIViewRepresentable {
         private func handleReplyGestureEnded(gesture: UIPanGestureRecognizer, textView: UITextView) {
             guard replyGhostView != nil else { return }
             let translation = gesture.translation(in: textView)
-            let horizontalTranslation = translation.x
+            let horizontalTranslation = swipeDirection == .right
+                ? min(max(0, translation.x), replyGestureThreshold)
+                : max(min(0, translation.x), -replyGestureThreshold)
 
             // Only trigger if it's a confirmed horizontal swipe
             if isHorizontalSwipe && abs(horizontalTranslation) >= replyGestureThreshold {
                 if swipeDirection == .right {
-                    print("Triggering reply action")
                     triggerReplyAction()
                 } else if swipeDirection == .left {
-                    print("Triggering delete action")
                     triggerDeleteAction()
                 }
             }

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1604,11 +1604,15 @@ struct RichTextEditor: UIViewRepresentable {
                 let iconAlpha = min(percentage, 1.0)
                 iconView.alpha = iconAlpha
 
-                let scale = 1.0 + (percentage) * 0.5 // Scale up to 1.5
-                iconView.transform = CGAffineTransform(scaleX: scale, y: scale)
+                if let progressContainer = self.holdProgressView {
+                    progressContainer.alpha = iconAlpha
+                }
 
                 // Handle hold-to-confirm for delete
                 if swipeDirection == .left {
+                    let scale = 1.0 + (percentage) * 0.1 // Scale up to 1.1
+                    iconView.transform = CGAffineTransform(scaleX: scale, y: scale)
+
                     if isAboveThreshold {
                         if !isHolding {
                             // Start hold
@@ -1649,6 +1653,9 @@ struct RichTextEditor: UIViewRepresentable {
                             }
                         }
                     }
+                } else {
+                    let scale = 1.0 + (percentage) * 0.5 // Scale up to 1.5
+                    iconView.transform = CGAffineTransform(scaleX: scale, y: scale)
                 }
             }
 
@@ -1703,13 +1710,13 @@ struct RichTextEditor: UIViewRepresentable {
         }
 
         private func createCircularProgressView() -> UIView {
-            let size: CGFloat = 44
+            let size: CGFloat = 52
             let progressView = UIView(frame: CGRect(x: 0, y: 0, width: size, height: size))
 
             // Create circular progress layer
             let progressLayer = CAShapeLayer()
             let center = CGPoint(x: size/2, y: size/2)
-            let radius: CGFloat = 18
+            let radius: CGFloat = 26
             let startAngle = -CGFloat.pi / 2 // Start at top
             let endAngle = startAngle + 2 * CGFloat.pi
 
@@ -1782,9 +1789,13 @@ struct RichTextEditor: UIViewRepresentable {
                 progressContainer.translatesAutoresizingMaskIntoConstraints = false
                 overlayView.addSubview(progressContainer)
 
+                // Position the progress indicator with manual offsets
+                let horizontalOffset: CGFloat = -62.5 // Adjust this to move left/right
+                let verticalOffset: CGFloat = -26 // Adjust this to move up/down
+
                 NSLayoutConstraint.activate([
-                    progressContainer.centerXAnchor.constraint(equalTo: iconView.centerXAnchor),
-                    progressContainer.centerYAnchor.constraint(equalTo: iconView.centerYAnchor)
+                    progressContainer.centerYAnchor.constraint(equalTo: overlayView.centerYAnchor, constant: verticalOffset),
+                    progressContainer.trailingAnchor.constraint(equalTo: overlayView.trailingAnchor, constant: horizontalOffset)
                 ])
 
                 holdProgressView = progressContainer
@@ -1959,6 +1970,10 @@ struct RichTextEditor: UIViewRepresentable {
                     ghostView.transform = CGAffineTransform.identity
                     overlayView.subviews.first?.alpha = 0.0
                     overlayView.subviews.first?.transform = .identity
+
+                    if let progressContainer = self.holdProgressView {
+                        progressContainer.alpha = 0.0
+                    }
                 },
                 completion: { _ in
                     cleanup()

--- a/notes2/RichTextEditor.swift
+++ b/notes2/RichTextEditor.swift
@@ -1554,7 +1554,14 @@ struct RichTextEditor: UIViewRepresentable {
             guard isHolding, let holdStartTime = holdStartTime else { return }
 
             let elapsed = CACurrentMediaTime() - holdStartTime
-            holdProgress = min(elapsed / holdDuration, 1.0)
+            let newProgress = min(elapsed / holdDuration, 1.0)
+            
+            // Check if we just reached 100%
+            if newProgress >= 1.0 && holdProgress < 1.0 {
+                holdHapticGenerator.impactOccurred()
+            }
+            
+            holdProgress = newProgress
 
             // Update progress indicator without implicit animations
             if let progressContainer = holdProgressView,
@@ -1563,15 +1570,6 @@ struct RichTextEditor: UIViewRepresentable {
                 CATransaction.setDisableActions(true)
                 progressLayer.strokeEnd = holdProgress
                 CATransaction.commit()
-            }
-
-            // Haptic feedback during hold
-            let hapticInterval: CFTimeInterval = 0.5
-            let currentInterval = Int(elapsed / hapticInterval)
-            let lastInterval = Int((elapsed - 0.016) / hapticInterval) // Small delta to prevent multiple triggers
-
-            if currentInterval > lastInterval && currentInterval <= 3 {
-                holdHapticGenerator.impactOccurred()
             }
         }
 


### PR DESCRIPTION
Extend the reply gesture in the opposite direction to delete the paragraph. Has a hold-to-confirm step with a progress bar to help avoid accidental paragraph deletion.